### PR TITLE
Enables generation of tables on hitting 'enter' on exact word. 

### DIFF
--- a/src/pages/InflectPage/components/Pali1AutoComplete/Pali1AutoComplete.tsx
+++ b/src/pages/InflectPage/components/Pali1AutoComplete/Pali1AutoComplete.tsx
@@ -57,7 +57,12 @@ export const Pali1AutoComplete = ({ db, initialValue, onChangePali1 }: Pali1Auto
   }
 
   const handleOpen = () => setOpen(true)
-  const handleClose = () => setOpen(false)
+  const handleClose = (_event: any) => {
+    if (_event.key === 'Enter') {
+      onChangePali1(_event.target.value)
+    }
+    setOpen(false)
+  }
 
   const handleChange = (_event: any, value: string, reason: string) => {
     if (reason !== 'select-option') {


### PR DESCRIPTION
Fix for problem mentioned by Ven B - 'hitting enter on an exact search does not generate a table, i have to delete the last letter of the words before the table will display.'  